### PR TITLE
Add charm config and functionality

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,34 +1,17 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
 
-# (Required)
-name: oauth2-proxy-k8s-operator
-
-
-# (Required)
+name: oauth2-proxy-k8s
 type: charm
-
-
-# (Recommended)
-title: Charm Template
-
-
-# (Required)
-summary: A very short one-line summary of the charm.
-
-
-# (Required)
+title: OAuth2 Proxy
+summary: A reverse proxy server that authenticates users through providers like Google and Github.
 description: |
-  A single sentence that says what the charm is, concisely and memorably.
+  OAuth2 Proxy is a reverse proxy and static file server that authenticates 
+  users through providers like Google and GitHub, allowing validation by email, 
+  domain, or group.
+links: 
+  documentation: https://discourse.charmhub.io/t/charmed-airbyte-ui-k8s-overview/14529 # TODO (kelkawi-a): change
 
-  A paragraph of one to three short sentences, that describe what the charm does.
-
-  A third paragraph that explains what need the charm meets.
-
-  Finally, a paragraph that describes whom the charm is useful for.
-
-
-# (Required for 'charm' type)
 bases:
   - build-on:
     - name: ubuntu
@@ -37,6 +20,11 @@ bases:
     - name: ubuntu
       channel: "22.04"
 
+# Metadata
+requires:
+  nginx-route:
+    interface: nginx-route
+    limit: 1
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
@@ -45,33 +33,75 @@ bases:
 # General configuration documentation: https://juju.is/docs/sdk/config
 config:
   options:
-    # An example config option to customise the log level of the workload
-    log-level:
+    upstream:
       description: |
-        Configures the log level of gunicorn.
-
-        Acceptable values are: "info", "debug", "warning", "error" and "critical"
-      default: "info"
+          The HTTP url(s) of the upstream endpoint. For juju applications, this is 
+          "http://<application_name>" if it is deployed on the same model.
+      default: ""
       type: string
 
+    provider:
+      description: |
+          OAuth provider.
 
-# The containers and resources metadata apply to Kubernetes charms only.
-# See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
+          Reference: https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/
+      default: "google"
+      type: string
 
-# Your workload’s containers.
+    client-id:
+      description: |
+          The OAuth Client ID.
+      default: ""
+      type: string
+
+    client-secret:
+      description: |
+          The OAuth Client Secret.
+      default: ""
+      type: string
+
+    cookie-secret:
+      description: |
+          The seed string for secure cookies (optionally base64 encoded).
+
+          Must be 16, 24, or 32 bytes to create an AES cipher.
+      default: ""
+      type: string
+
+    authenticated-emails-list:
+      description: |
+          Comma-separated list of users to allow to authenticate to the service.
+      default: ""
+      type: string
+
+    additional-config:
+      description: |
+          Space-separated list of additional config as defined in 
+          https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/.
+
+          Example: '--upstream-timeout=20s --whitelist-domain=example.com'
+      default: "--email-domain=*"
+      type: string
+
+    external-hostname:
+      description: |
+          The DNS listing used for external connections. Will default to the name of the deployed
+          application.
+      default: "oauth2-proxy-k8s"
+      type: string
+
+    tls-secret-name:
+      description: |
+          Name of the k8s secret which contains the TLS certificate to be used by ingress.
+      default: "oauth2-proxy-tls"
+      type: string
+
 containers:
-  some-container:
-    resource: some-container-image
+  oauth2-proxy:
+    resource: oauth2-proxy-image
 
-
-# This field populates the Resources tab on Charmhub.
 resources:
-  # An OCI image resource for each container listed above.
-  # You may remove this if your charm will run without a workload sidecar container.
-  some-container-image:
+  oauth2-proxy-image:
     type: oci-image
     description: OCI image for the 'some-container' container
-    # The upstream-source field is ignored by Juju. It is included here as a reference
-    # so the integration testing suite knows which image to deploy during testing. This field
-    # is also used by the 'canonical/charming-actions' Github action for automated releasing.
-    upstream-source: some-repo/some-image:some-tag
+    upstream-source: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0-alpine

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,22 +6,214 @@
 
 import logging
 
-import ops
+from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
+from ops import main, pebble
+from ops.charm import CharmBase
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.pebble import CheckStatus
+
+from log import log_event_handler
 
 logger = logging.getLogger(__name__)
 
+HTTP_PORT = 80
+OAUTH2_PROXY_VERSION = "v7.6.0"
 
-class Oauth2ProxyK8SOperatorCharm(ops.CharmBase):
-    """Charm the application."""
 
-    def __init__(self, framework: ops.Framework):
-        super().__init__(framework)
-        framework.observe(self.on["some_container"].pebble_ready, self._on_pebble_ready)
+class Oauth2ProxyK8SOperatorCharm(CharmBase):
+    """Charm the application.
 
-    def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
-        """Handle pebble-ready event."""
-        self.unit.status = ops.ActiveStatus()
+    Attrs:
+        external_hostname: DNS listing used for external connections.
+    """
+
+    def __init__(self, *args):
+        """Construct.
+
+        Args:
+            args: Ignore.
+        """
+        super().__init__(*args)
+
+        self.name = "oauth2-proxy"
+        self.framework.observe(self.on[self.name].pebble_ready, self._on_pebble_ready)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.restart_action, self._on_restart)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
+
+        # Handle Ingress.
+        self._require_nginx_route()
+
+    @property
+    def external_hostname(self):
+        """Return the DNS listing used for external connections."""
+        return self.config["external-hostname"] or self.app.name
+
+    def _require_nginx_route(self):
+        """Require nginx-route relation based on current configuration."""
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.external_hostname,
+            service_name=self.app.name,
+            service_port=HTTP_PORT,
+            tls_secret_name=self.config["tls-secret-name"],
+            backend_protocol="HTTP",
+        )
+
+    @log_event_handler(logger)
+    def _on_pebble_ready(self, event):
+        """Handle pebble ready event.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        self._update(event)
+
+    @log_event_handler(logger)
+    def _on_config_changed(self, event):
+        """Handle configuration changes.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        self.unit.status = WaitingStatus("configuring application")
+        self._update(event)
+
+    @log_event_handler(logger)
+    def _on_update_status(self, event):
+        """Handle `update-status` events.
+
+        Args:
+            event: The `update-status` event triggered at intervals.
+        """
+        try:
+            self._validate()
+        except ValueError:
+            return
+
+        container = self.unit.get_container(self.name)
+        valid_pebble_plan = self._validate_pebble_plan(container)
+        if not valid_pebble_plan:
+            self._update(event)
+            return
+
+        check = container.get_check("up")
+        if check.status != CheckStatus.UP:
+            self.unit.status = MaintenanceStatus("Status check: DOWN")
+            return
+
+        self.unit.set_workload_version(OAUTH2_PROXY_VERSION)
+        self.unit.status = ActiveStatus()
+
+    def _validate_pebble_plan(self, container):
+        """Validate pebble plan.
+
+        Args:
+            container: application container
+
+        Returns:
+            bool of pebble plan validity
+        """
+        try:
+            plan = container.get_plan().to_dict()
+            return bool(plan["services"][self.name]["on-check-failure"])
+        except (KeyError, pebble.ConnectionError):
+            return False
+
+    def _on_restart(self, event):
+        """Restart application action handler.
+
+        Args:
+            event:The event triggered by the restart action
+        """
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.defer()
+            return
+
+        self.unit.status = MaintenanceStatus("restarting application")
+        container.restart(self.name)
+
+        event.set_results({"result": "application successfully restarted"})
+
+    def _validate(self):
+        """Validate that configuration and relations are valid and ready.
+
+        Raises:
+            ValueError: in case of invalid configuration.
+        """
+        if not self.config["upstream"]:
+            raise ValueError("missing `upstream` config")
+
+        if not self.config["cookie-secret"]:
+            raise ValueError("missing `cookie-secret` config")
+
+        if self.config["provider"] == "google" and (not self.config["client-id"] or not self.config["client-secret"]):
+            raise ValueError("`client-id` and `client-secret` config must be set for `google` provider")
+
+        if not self.config["authenticated-emails-list"] and "--email-domain=" not in self.config["additional-config"]:
+            raise ValueError(
+                "`--email-domain` must be set using `additional-config` if not setting `authenticated-emails-list`"
+            )
+
+    @log_event_handler(logger)
+    def _update(self, event):
+        """Update the application configuration and replan its execution.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        try:
+            self._validate()
+        except ValueError as err:
+            self.unit.status = BlockedStatus(str(err))
+            return
+
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.defer()
+            return
+
+        command = f"/bin/oauth2-proxy --http-address=0.0.0.0:{HTTP_PORT}"
+        for param in ["upstream", "provider", "client-id", "client-secret", "cookie-secret"]:
+            if self.config[param]:
+                command += f" --{param}={self.config[param]}"
+
+        if self.config["authenticated-emails-list"]:
+            users = "\n".join(self.config["authenticated-emails-list"].split(","))
+            filename = "/etc/oauth2_proxy/access_list.cfg"
+            container.push(filename, users, make_dirs=True)
+            command += f" --authenticated-emails-file={filename}"
+
+        if self.config["additional-config"]:
+            command += f" {self.config['additional-config']}"
+
+        self.model.unit.set_ports(HTTP_PORT)
+        pebble_layer = {
+            "summary": "oauth2 proxy layer",
+            "services": {
+                self.name: {
+                    "summary": self.name,
+                    "command": command,
+                    "startup": "enabled",
+                    "override": "replace",
+                    "on-check-failure": {"up": "ignore"},
+                }
+            },
+            "checks": {
+                "up": {
+                    "override": "replace",
+                    "period": "10s",
+                    "http": {"url": f"http://localhost:{HTTP_PORT}/ready"},
+                }
+            },
+        }
+
+        container.add_layer(self.name, pebble_layer, combine=True)
+        container.replan()
+
+        self.unit.status = MaintenanceStatus("replanning application")
 
 
 if __name__ == "__main__":  # pragma: nocover
-    ops.main(Oauth2ProxyK8SOperatorCharm)  # type: ignore
+    main.main(Oauth2ProxyK8SOperatorCharm)  # type: ignore


### PR DESCRIPTION
This PR:
- Adds the charm's core functionality and main configuration parameters outlined in the [official docs](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/). Given that these config values can be passed as flags when starting the service, I opted not to include all of them as charm configurations, but rather a small subset of them, and the rest can be passed under the `additional-config` parameter.
- Adds a relation to the `nginx-ingress-integrator` charm to enable ingress.

Unit and integration tests PRs will follow.