### PR TITLE
Integrate with `auth-proxy` and `forward-auth`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,22 +39,15 @@ requires:
     interface: oauth
     limit: 1
 
+provides:
+  auth-proxy:
+    interface: auth_proxy
+  forward-auth:
+    interface: forward_auth
+
 peers:
   oauth2-proxy:
     interface: oauth2_proxy_peers
-
-# This config section defines charm config options, and populates the Configure
-# tab on Charmhub.
-# More information on this section at https://juju.is/docs/sdk/charmcraft-yaml#heading--config
-# General configuration documentation: https://juju.is/docs/sdk/config
-config:
-  options:
-
-    authenticated-emails-list:
-      description: |
-          Comma-separated list of users to allow to authenticate to the service.
-      default: ""
-      type: string
 
 containers:
   oauth2-proxy:

--- a/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
+++ b/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Interface library for providing OAuth2 Proxy with downstream charms' auth-proxy information.
+
+It is required to integrate a charm into an Identity and Access Proxy (IAP).
+
+## Getting Started
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+**Note that you also need to add `jsonschema` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.oauth2_proxy_k8s.v0.auth_proxy
+```
+
+To use the library from the requirer side, add the following to the `metadata.yaml` of the charm:
+
+```yaml
+requires:
+  auth-proxy:
+    interface: auth_proxy
+    limit: 1
+```
+
+Then, to initialise the library:
+```python
+from charms.oauth2_proxy_k8s.v0.auth_proxy import AuthProxyConfig, AuthProxyRequirer
+
+AUTH_PROXY_ALLOWED_ENDPOINTS = ["welcome", "about/app"]
+AUTH_PROXY_HEADERS = ["X-Auth-Request-User", "X-Auth-Request-Email"]
+AUTH_PROXY_AUTHENTICATED_EMAILS = ["test@example.com", "test@canonical.com"]
+AUTH_PROXY_AUTHENTICATED_EMAIL_DOMAINS = ["canonical.com"]
+
+class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        # ...
+        self.auth_proxy = AuthProxyRequirer(self, self._auth_proxy_config)
+
+        @property
+        def external_urls(self) -> list:
+            # Get ingress-per-unit or externally-configured web urls
+            # ...
+            return ["https://example.com/unit-0", "https://example.com/unit-1"]
+
+        @property
+        def _auth_proxy_config(self) -> AuthProxyConfig:
+            return AuthProxyConfig(
+                protected_urls=self.external_urls,
+                allowed_endpoints=AUTH_PROXY_ALLOWED_ENDPOINTS,
+                headers=AUTH_PROXY_HEADERS,
+                authenticated_emails=AUTH_PROXY_AUTHENTICATED_EMAILS,
+                authenticated_email_domains=AUTH_PROXY_AUTHENTICATED_EMAIL_DOMAINS
+            )
+
+        def _on_ingress_ready(self, event):
+            self._configure_auth_proxy()
+
+        def _configure_auth_proxy(self):
+            self.auth_proxy.update_auth_proxy_config(auth_proxy_config=self._auth_proxy_config)
+```
+"""
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Mapping, Optional
+
+import jsonschema
+from ops.charm import CharmBase, RelationBrokenEvent, RelationChangedEvent, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
+from ops.model import Relation, TooManyRelatedAppsError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "83df2500c289431aab1567ac1b780926"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "auth-proxy"
+INTERFACE_NAME = "auth_proxy"
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_HEADERS = ["X-Auth-Request-User", "X-Auth-Request-Groups", "X-Auth-Request-Email", "X-Auth-Request-Preferred-Username"]
+
+url_regex = re.compile(
+    r"(^http://)|(^https://)"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|"
+    r"[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+AUTH_PROXY_REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/docs/json_schemas/auth_proxy/v0/requirer.json",
+    "type": "object",
+    "properties": {
+        "protected_urls": {"type": "array", "default": None, "items": {"type": "string"}},
+        "allowed_endpoints": {"type": "array", "default": [], "items": {"type": "string"}},
+        "headers": {
+            "type": "array",
+            "default": ["X-Auth-Request-User"],
+            "items": {
+                "enum": ALLOWED_HEADERS,
+                "type": "string",
+            },
+        },
+        "authenticated_emails": {"type": "array", "default": [], "items": {"type": "string"}},
+        "authenticated_email_domains": {"type": "array", "default": [], "items": {"type": "string"}},
+    },
+    "required": ["protected_urls", "allowed_endpoints", "headers", "authenticated_emails", "authenticated_email_domains"],
+}
+
+
+class AuthProxyConfigError(Exception):
+    """Emitted when invalid auth proxy config is provided."""
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on relation data."""
+
+
+def _load_data(data: Mapping, schema: Optional[Dict] = None) -> Dict:
+    """Parses nested fields and checks whether `data` matches `schema`."""
+    ret = {}
+    for k, v in data.items():
+        try:
+            ret[k] = json.loads(v)
+        except json.JSONDecodeError:
+            ret[k] = v
+
+    if schema:
+        _validate_data(ret, schema)
+    return ret
+
+
+def _dump_data(data: Dict, schema: Optional[Dict] = None) -> Dict:
+    if schema:
+        _validate_data(data, schema)
+
+    ret = {}
+    for k, v in data.items():
+        if isinstance(v, (list, dict)):
+            try:
+                ret[k] = json.dumps(v)
+            except json.JSONDecodeError as e:
+                raise DataValidationError(f"Failed to encode relation json: {e}")
+        else:
+            ret[k] = v
+    return ret
+
+
+class AuthProxyRelation(Object):
+    """A class containing helper methods for auth-proxy relation."""
+
+    def _pop_relation_data(self, relation_id: Relation) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        if not self._charm.model.relations[self._relation_name]:
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        if not relation or not relation.app:
+            return
+
+        try:
+            for data in list(relation.data[self.model.app]):
+                relation.data[self.model.app].pop(data, "")
+        except Exception as e:
+            logger.info("Failed to pop the relation data: %s", e)
+
+
+def _validate_data(data: Dict, schema: Dict) -> None:
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+@dataclass
+class AuthProxyConfig:
+    """Helper class containing a configuration for the charm related with OAuth2 Proxy."""
+
+    protected_urls: List[str]
+    headers: List[str] = field(default_factory=lambda: [])
+    allowed_endpoints: List[str] = field(default_factory=lambda: [])
+    authenticated_emails: List[str] = field(default_factory=lambda: [])
+    authenticated_email_domains: List[str] = field(default_factory=lambda: [])
+
+    def validate(self) -> None:
+        """Validate the auth proxy configuration."""
+        # Validate protected_urls
+        for url in self.protected_urls:
+            if not re.match(url_regex, url):
+                raise AuthProxyConfigError(f"Invalid URL {url}")
+
+        for url in self.protected_urls:
+            if url.startswith("http://"):
+                logger.warning("Provided URL %s uses http scheme. Don't do this in production", url)
+
+        # Validate headers
+        for header in self.headers:
+            if header not in ALLOWED_HEADERS:
+                raise AuthProxyConfigError(
+                    f"Unsupported header {header}, it must be one of {ALLOWED_HEADERS}"
+                )
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+class AuthProxyConfigChangedEvent(EventBase):
+    """Event to notify the Provider charm that the auth proxy config has changed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        protected_urls: List[str],
+        headers: List[str],
+        allowed_endpoints: List[str],
+        authenticated_emails: List[str],
+        authenticated_email_domains: List[str],
+        relation_id: int,
+        relation_app_name: str,
+    ) -> None:
+        super().__init__(handle)
+        self.protected_urls = protected_urls
+        self.allowed_endpoints = allowed_endpoints
+        self.headers = headers
+        self.authenticated_emails = authenticated_emails
+        self.authenticated_email_domains = authenticated_email_domains
+        self.relation_id = relation_id
+        self.relation_app_name = relation_app_name
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "protected_urls": self.protected_urls,
+            "headers": self.headers,
+            "allowed_endpoints": self.allowed_endpoints,
+            "authenticated_emails": self.authenticated_emails,
+            "authenticated_email_domains": self.authenticated_email_domains,
+            "relation_id": self.relation_id,
+            "relation_app_name": self.relation_app_name,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.protected_urls = snapshot["protected_urls"]
+        self.headers = snapshot["headers"]
+        self.allowed_endpoints = snapshot["allowed_endpoints"]
+        self.authenticated_emails = snapshot["authenticated_emails"]
+        self.authenticated_email_domains = snapshot["authenticated_email_domains"]
+        self.relation_id = snapshot["relation_id"]
+        self.relation_app_name = snapshot["relation_app_name"]
+
+    def to_auth_proxy_config(self) -> AuthProxyConfig:
+        """Convert the event information to an AuthProxyConfig object."""
+        return AuthProxyConfig(
+            self.protected_urls,
+            self.allowed_endpoints,
+            self.headers,
+            self.authenticated_emails,
+            self.authenticated_email_domains,
+        )
+
+
+class AuthProxyConfigRemovedEvent(EventBase):
+    """Event to notify the provider charm that the auth proxy config was removed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class AuthProxyProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `AuthProxyProvider`."""
+
+    proxy_config_changed = EventSource(AuthProxyConfigChangedEvent)
+    config_removed = EventSource(AuthProxyConfigRemovedEvent)
+
+
+class AuthProxyProvider(AuthProxyRelation):
+    """Provider side of the auth-proxy relation."""
+
+    on = AuthProxyProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME) -> None:
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Get the auth-proxy config and emit a custom config-changed event."""
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No requirer relation data available.")
+            return
+
+        try:
+            auth_proxy_data = _load_data(data, AUTH_PROXY_REQUIRER_JSON_SCHEMA)
+        except DataValidationError as e:
+            logger.error(
+                "Received invalid config from the requirer: %s. Config-changed will not be emitted", e
+            )
+            return
+
+        protected_urls = auth_proxy_data.get("protected_urls")
+        allowed_endpoints = auth_proxy_data.get("allowed_endpoints")
+        headers = auth_proxy_data.get("headers")
+        authenticated_emails = auth_proxy_data.get("authenticated_emails")
+        authenticated_email_domains = auth_proxy_data.get("authenticated_email_domains")
+
+        relation_id = event.relation.id
+        relation_app_name = event.relation.app.name
+
+        # Notify OAuth2 Proxy to reconfigure
+        self.on.proxy_config_changed.emit(
+            protected_urls, headers, allowed_endpoints, authenticated_emails, authenticated_email_domains, relation_id, relation_app_name
+        )
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        """Wipe the relation databag and notify OAuth2 Proxy that the relation is broken."""
+        # Workaround for https://github.com/canonical/operator/issues/888
+        self._pop_relation_data(event.relation.id)
+
+        self.on.config_removed.emit(event.relation.id)
+
+    def get_app_names(self) -> List[str]:
+        """Returns the list of all related app names."""
+        if not self._charm.model.relations[self._relation_name]:
+            return []
+
+        app_names = []
+        for relation in self._charm.model.relations[self._relation_name]:
+            if relation.data[relation.app]:
+                app_names.append(relation.app.name)
+
+        return app_names
+
+    def get_relations_data(self, key: str) -> Optional[List[str]]:
+        """Returns a list of key values from all auth-proxy relations."""
+        if not self._charm.model.relations[self._relation_name]:
+            return None
+
+        relations_data = set()
+        for relation in self._charm.model.relations[self._relation_name]:
+            if relation.data[relation.app]:
+                if values := json.loads(relation.data[relation.app][key]):
+                    for v in values:
+                        relations_data.add(v)
+                else:
+                    return None
+
+        return list(relations_data)
+
+
+class InvalidAuthProxyConfigEvent(EventBase):
+    """Event to notify the charm that the auth proxy configuration is invalid."""
+
+    def __init__(self, handle: Handle, error: str) -> None:
+        super().__init__(handle)
+        self.error = error
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "error": self.error,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.error = snapshot["error"]
+
+
+class AuthProxyRelationRemovedEvent(EventBase):
+    """Custom event to notify the charm that the relation was removed."""
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        pass
+
+
+class AuthProxyRequirerEvents(ObjectEvents):
+    """Event descriptor for events raised by `AuthProxyRequirer`."""
+
+    invalid_auth_proxy_config = EventSource(InvalidAuthProxyConfigEvent)
+    auth_proxy_relation_removed = EventSource(AuthProxyRelationRemovedEvent)
+
+
+class AuthProxyRequirer(AuthProxyRelation):
+    """Requirer side of the auth-proxy relation."""
+
+    on = AuthProxyRequirerEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        auth_proxy_config: Optional[AuthProxyConfig] = None,
+        relation_name: str = RELATION_NAME,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._auth_proxy_config = auth_proxy_config
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Update the relation with auth proxy config when a relation is created."""
+        if not self.model.unit.is_leader():
+            return
+
+        try:
+            self._update_relation_data(self._auth_proxy_config, event.relation.id)
+        except AuthProxyConfigError as e:
+            self.on.invalid_auth_proxy_config.emit(e.args[0])
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        """Wipe the relation databag and notify the charm when the relation is broken."""
+        # Workaround for https://github.com/canonical/operator/issues/888
+        self._pop_relation_data(event.relation.id)
+
+        self.on.auth_proxy_relation_removed.emit()
+
+    def _update_relation_data(
+        self, auth_proxy_config: Optional[AuthProxyConfig], relation_id: Optional[int] = None
+    ) -> None:
+        """Validate the auth-proxy config and update the relation databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        if not auth_proxy_config:
+            logger.info("Auth proxy config is missing")
+            return
+
+        if not isinstance(auth_proxy_config, AuthProxyConfig):
+            raise ValueError(f"Unexpected auth_proxy_config type: {type(auth_proxy_config)}")
+
+        auth_proxy_config.validate()
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation or not relation.app:
+            return
+
+        data = _dump_data(auth_proxy_config.to_dict(), AUTH_PROXY_REQUIRER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def update_auth_proxy_config(
+        self, auth_proxy_config: AuthProxyConfig, relation_id: Optional[int] = None
+    ) -> None:
+        """Update the auth proxy config stored in the object."""
+        self._update_relation_data(auth_proxy_config, relation_id=relation_id)
+

--- a/lib/charms/oauth2_proxy_k8s/v0/forward_auth.py
+++ b/lib/charms/oauth2_proxy_k8s/v0/forward_auth.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Interface library for providing API Gateways with Identity and Access Proxy information.
+
+It is required to integrate with OAuth2 Proxy - a reverse proxy and static file server that provides authentication
+using Identity Platform's built-in identity management system and integrated identity providers (Google, GitHub, and others).
+
+## Getting Started
+
+To get started using the library, you need to fetch the library using `charmcraft`.
+**Note that you also need to add `jsonschema` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.oauth2_proxy_k8s.v0.forward_auth
+```
+
+To use the library from the requirer side, add the following to the `metadata.yaml` of the charm:
+
+```yaml
+requires:
+  forward-auth:
+    interface: forward_auth
+    limit: 1
+```
+
+Then, to initialise the library:
+```python
+from charms.oauth2_proxy_k8s.v0.forward_auth import AuthConfigChangedEvent, ForwardAuthRequirer
+
+class ApiGatewayCharm(CharmBase):
+    def __init__(self, *args):
+        # ...
+        self.forward_auth = ForwardAuthRequirer(self)
+        self.framework.observe(
+            self.forward_auth.on.auth_config_changed,
+            self.some_event_function
+            )
+
+    def some_event_function(self, event: AuthConfigChangedEvent):
+        if self.forward_auth.is_ready():
+            # Fetch the relation info
+            forward_auth_data = self.forward_auth.get_forward_auth_data()
+            # update ingress configuration
+            # ...
+```
+"""
+
+import inspect
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Mapping, Optional
+
+import jsonschema
+from ops.charm import CharmBase, RelationBrokenEvent, RelationChangedEvent, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
+from ops.model import Relation, TooManyRelatedAppsError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e49a5628b4af489cb6e55a8f35974199"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "forward-auth"
+INTERFACE_NAME = "forward_auth"
+
+logger = logging.getLogger(__name__)
+
+FORWARD_AUTH_PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/docs/json_schemas/forward_auth/v0/provider.json",
+    "type": "object",
+    "properties": {
+        "decisions_address": {"type": "string", "default": None},
+        "app_names": {"type": "array", "default": None, "items": {"type": "string"}},
+        "headers": {"type": "array", "default": None, "items": {"type": "string"}},
+    },
+    "required": ["decisions_address", "app_names"],
+}
+
+FORWARD_AUTH_REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/docs/json_schemas/forward_auth/v0/requirer.json",
+    "type": "object",
+    "properties": {
+        "ingress_app_names": {"type": "array", "default": None, "items": {"type": "string"}},
+    },
+    "required": ["ingress_app_names"],
+}
+
+
+class ForwardAuthConfigError(Exception):
+    """Emitted when invalid forward auth config is provided."""
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on relation data."""
+
+
+def _load_data(data: Mapping, schema: Optional[Dict] = None) -> Dict:
+    """Parses nested fields and checks whether `data` matches `schema`."""
+    ret = {}
+    for k, v in data.items():
+        try:
+            ret[k] = json.loads(v)
+        except json.JSONDecodeError:
+            ret[k] = v
+
+    if schema:
+        _validate_data(ret, schema)
+    return ret
+
+
+def _dump_data(data: Dict, schema: Optional[Dict] = None) -> Dict:
+    if schema:
+        _validate_data(data, schema)
+
+    ret = {}
+    for k, v in data.items():
+        if isinstance(v, (list, dict)):
+            try:
+                ret[k] = json.dumps(v)
+            except json.JSONDecodeError as e:
+                raise DataValidationError(f"Failed to encode relation json: {e}")
+        else:
+            ret[k] = v
+    return ret
+
+
+class ForwardAuthRelation(Object):
+    """A class containing helper methods for forward-auth relation."""
+
+    def _pop_relation_data(self, relation_id: Relation) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        if len(self.model.relations) == 0:
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        if not relation or not relation.app:
+            return
+
+        try:
+            for data in list(relation.data[self.model.app]):
+                relation.data[self.model.app].pop(data, "")
+        except Exception as e:
+            logger.info(f"Failed to pop the relation data: {e}")
+
+
+def _validate_data(data: Dict, schema: Dict) -> None:
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+@dataclass
+class ForwardAuthConfig:
+    """Helper class containing configuration required by API Gateway to set up the proxy."""
+
+    decisions_address: str
+    app_names: List[str]
+    headers: List[str] = field(default_factory=lambda: [])
+
+    @classmethod
+    def from_dict(cls, dic: Dict) -> "ForwardAuthConfig":
+        """Generate ForwardAuthConfig instance from dict."""
+        return cls(**{k: v for k, v in dic.items() if k in inspect.signature(cls).parameters})
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass
+class ForwardAuthRequirerConfig:
+    """Helper class containing configuration required by OAuth2 Proxy.
+
+    Its purpose is to evaluate whether apps can be protected by IAP.
+    """
+
+    ingress_app_names: List[str] = field(default_factory=lambda: [])
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+class AuthConfigChangedEvent(EventBase):
+    """Event to notify the requirer charm that the forward-auth config has changed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        decisions_address: str,
+        app_names: List[str],
+        headers: List[str],
+        relation_id: int,
+        relation_app_name: str,
+    ) -> None:
+        super().__init__(handle)
+        self.decisions_address = decisions_address
+        self.app_names = app_names
+        self.headers = headers
+        self.relation_id = relation_id
+        self.relation_app_name = relation_app_name
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "decisions_address": self.decisions_address,
+            "app_names": self.app_names,
+            "headers": self.headers,
+            "relation_id": self.relation_id,
+            "relation_app_name": self.relation_app_name,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.decisions_address = snapshot["decisions_address"]
+        self.app_names = snapshot["app_names"]
+        self.headers = snapshot["headers"]
+        self.relation_id = snapshot["relation_id"]
+        self.relation_app_name = snapshot["relation_app_name"]
+
+
+class AuthConfigRemovedEvent(EventBase):
+    """Event to notify the requirer charm that the forward-auth config was removed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class ForwardAuthRequirerEvents(ObjectEvents):
+    """Event descriptor for events raised by `ForwardAuthRequirer`."""
+
+    auth_config_changed = EventSource(AuthConfigChangedEvent)
+    auth_config_removed = EventSource(AuthConfigRemovedEvent)
+
+
+class ForwardAuthRequirer(ForwardAuthRelation):
+    """Requirer side of the forward-auth relation."""
+
+    on = ForwardAuthRequirerEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        *,
+        relation_name: str = RELATION_NAME,
+        ingress_app_names: Optional[ForwardAuthRequirerConfig] = None,
+    ) -> None:
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+        self._ingress_app_names = ingress_app_names
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Get the forward-auth config and emit a custom config-changed event."""
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.debug("No provider relation data available.")
+            return
+
+        try:
+            forward_auth_data = _load_data(data, FORWARD_AUTH_PROVIDER_JSON_SCHEMA)
+        except DataValidationError as e:
+            logger.error(
+                f"Received invalid config from the provider: {e}. Config-changed will not be emitted."
+            )
+            return
+
+        decisions_address = forward_auth_data.get("decisions_address")
+        app_names = forward_auth_data.get("app_names")
+        headers = forward_auth_data.get("headers")
+
+        relation_id = event.relation.id
+        relation_app_name = event.relation.app.name
+
+        # Notify Traefik to update the routes
+        self.on.auth_config_changed.emit(
+            decisions_address, app_names, headers, relation_id, relation_app_name
+        )
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        """Notify the requirer that the relation was broken."""
+        self.on.auth_config_removed.emit(event.relation.id)
+
+    def update_requirer_relation_data(
+        self,
+        ingress_app_names: Optional[ForwardAuthRequirerConfig],
+        relation_id: Optional[int] = None,
+    ) -> None:
+        """Update the relation databag with app names that can get IAP protection."""
+        if not self.model.unit.is_leader():
+            return
+
+        if not ingress_app_names:
+            logger.error("Ingress-related app names are missing")
+            return
+
+        if not isinstance(ingress_app_names, ForwardAuthRequirerConfig):
+            raise TypeError(f"Unexpected type: {type(ingress_app_names)}")
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+
+        if not relation or not relation.app:
+            return
+
+        data = _dump_data(ingress_app_names.to_dict(), FORWARD_AUTH_REQUIRER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def get_provider_info(self, relation_id: Optional[int] = None) -> Optional[ForwardAuthConfig]:
+        """Get the provider information from the databag."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+        if not relation or not relation.app:
+            return None
+
+        data = relation.data[relation.app]
+        if not data:
+            logger.debug("No relation data available.")
+            return None
+
+        data = _load_data(data, FORWARD_AUTH_PROVIDER_JSON_SCHEMA)
+        forward_auth_config = ForwardAuthConfig.from_dict(data)
+        logger.debug(f"ForwardAuthConfig: {forward_auth_config}")
+
+        return forward_auth_config
+
+    def get_remote_app_name(self, relation_id: Optional[int] = None) -> Optional[str]:
+        """Get the remote app name."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+        if not relation or not relation.app:
+            return None
+
+        return relation.app.name
+
+    def is_ready(self, relation_id: Optional[int] = None) -> Optional[bool]:
+        """Checks whether ForwardAuth is ready on this relation.
+
+        Returns True when OAuth2 Proxy shared the config; False otherwise.
+        """
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+
+        if not relation or not relation.app:
+            return None
+
+        return (
+            "decisions_address" in relation.data[relation.app]
+            and "app_names" in relation.data[relation.app]
+        )
+
+    def is_protected_app(self, app: Optional[str]) -> bool:
+        """Checks whether a given app requested to be protected by IAP."""
+        if self.is_ready():
+            forward_auth_config = self.get_provider_info()
+            if forward_auth_config and app in forward_auth_config.app_names:
+                return True
+            return False
+
+        return False
+
+
+class ForwardAuthProxySet(EventBase):
+    """Event to notify the charm that the proxy was set successfully."""
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        pass
+
+
+class InvalidForwardAuthConfigEvent(EventBase):
+    """Event to notify the charm that the forward-auth configuration is invalid."""
+
+    def __init__(self, handle: Handle, error: str) -> None:
+        super().__init__(handle)
+        self.error = error
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "error": self.error,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.error = snapshot["error"]
+
+
+class ForwardAuthRelationRemovedEvent(EventBase):
+    """Event to notify the charm that the relation was removed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class ForwardAuthProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `ForwardAuthProvider`."""
+
+    forward_auth_proxy_set = EventSource(ForwardAuthProxySet)
+    invalid_forward_auth_config = EventSource(InvalidForwardAuthConfigEvent)
+    forward_auth_relation_removed = EventSource(ForwardAuthRelationRemovedEvent)
+
+
+class ForwardAuthProvider(ForwardAuthRelation):
+    """Provider side of the forward-auth relation."""
+
+    on = ForwardAuthProviderEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = RELATION_NAME,
+        forward_auth_config: Optional[ForwardAuthConfig] = None,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self._relation_name = relation_name
+        self.forward_auth_config = forward_auth_config
+
+        events = self.charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created_event)
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+        self.framework.observe(events.relation_broken, self._on_relation_broken_event)
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Update the relation with provider data when a relation is created."""
+        if not self.model.unit.is_leader():
+            return
+
+        try:
+            self._update_relation_data(self.forward_auth_config, event.relation.id)
+        except ForwardAuthConfigError as e:
+            self.on.invalid_forward_auth_config.emit(e.args[0])
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Update the relation with forward-auth config when a relation is changed."""
+        if not self.model.unit.is_leader():
+            return
+
+        # Compare ingress-related apps with apps that requested the proxy
+        self._compare_apps()
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        """Wipe the relation databag and notify the charm that the relation is broken."""
+        # Workaround for https://github.com/canonical/operator/issues/888
+        self._pop_relation_data(event.relation.id)
+
+        self.on.forward_auth_relation_removed.emit(event.relation.id)
+
+    def _compare_apps(self, relation_id: Optional[int] = None) -> None:
+        """Compare app names provided by OAuth2 Proxy with apps that are related via ingress.
+
+        The ingress-related app names are provided by the relation requirer.
+        If an app is not related via ingress-per-app/leader/unit,
+        emit `InvalidForwardAuthConfigEvent`.
+        If the app is related via ingress and thus eligible for IAP, emit `ForwardAuthProxySet`.
+        """
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+        if not relation or not relation.app:
+            return None
+
+        requirer_data = relation.data[relation.app]
+        if not requirer_data:
+            logger.info("No requirer relation data available.")
+            return
+
+        ingress_apps = requirer_data["ingress_app_names"]
+
+        for app in json.loads(relation.data[self.model.app]["app_names"]):
+            if app not in ingress_apps:
+                self.on.invalid_forward_auth_config.emit(error=f"{app} is not related via ingress")
+                return
+            self.on.forward_auth_proxy_set.emit()
+
+    def _update_relation_data(
+        self, forward_auth_config: Optional[ForwardAuthConfig], relation_id: Optional[int] = None
+    ) -> None:
+        """Validate the forward-auth config and update the relation databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        if not forward_auth_config:
+            logger.info("Forward-auth config is missing")
+            return
+
+        if not isinstance(forward_auth_config, ForwardAuthConfig):
+            raise TypeError(f"Unexpected forward_auth_config type: {type(forward_auth_config)}")
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise TooManyRelatedAppsError(
+                "More than one relation is defined. Please provide a relation_id"
+            )
+
+        if not relation or not relation.app:
+            return
+
+        data = _dump_data(forward_auth_config.to_dict(), FORWARD_AUTH_PROVIDER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def update_forward_auth_config(
+        self, forward_auth_config: ForwardAuthConfig, relation_id: Optional[int] = None
+    ) -> None:
+        """Update the forward-auth config stored in the object."""
+        self._update_relation_data(forward_auth_config, relation_id=relation_id)
+

--- a/src/constants.py
+++ b/src/constants.py
@@ -18,4 +18,7 @@ NO_PROXY = "JUJU_CHARM_NO_PROXY"
 OAUTH_SCOPES = "openid email profile offline_access"
 OAUTH_GRANT_TYPES = ["authorization_code", "refresh_token"]
 
+AUTH_PROXY_RELATION_NAME = "auth-proxy"
+FORWARD_AUTH_RELATION_NAME = "forward-auth"
+
 PEER = "oauth2-proxy"

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from dataclasses import dataclass, field
+from typing import List
+
+from charms.oauth2_proxy_k8s.v0.auth_proxy import AuthProxyProvider
+
+
+@dataclass(frozen=True, slots=True)
+class AuthProxyIntegrationData:
+    """Data source from the auth-proxy integration."""
+
+    app_names: List[str] = field(default_factory=list)
+    allowed_endpoints: List[str] = field(default_factory=list)
+    headers: List[str] = field(default_factory=list)
+    authenticated_emails: List[str] = field(default_factory=list)
+    authenticated_email_domains: List[str] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, provider: AuthProxyProvider) -> "AuthProxyIntegrationData":
+        app_names = provider.get_app_names()
+        allowed_endpoints = provider.get_relations_data("allowed_endpoints")
+        headers = provider.get_relations_data("headers")
+        authenticated_emails = provider.get_relations_data("authenticated_emails")
+        authenticated_email_domains = provider.get_relations_data("authenticated_email_domains")
+
+        return cls(
+            app_names=app_names,
+            allowed_endpoints=allowed_endpoints,
+            headers=headers,
+            authenticated_emails=authenticated_emails,
+            authenticated_email_domains=authenticated_email_domains,
+        )

--- a/templates/oauth2-proxy.toml.j2
+++ b/templates/oauth2-proxy.toml.j2
@@ -1,4 +1,6 @@
 http_address="0.0.0.0:4180"
+ssl_insecure_skip_verify="true"
+redirect_url="{{ redirect_url }}"
 
 client_secret="{{ client_secret }}"
 client_id="{{ client_id }}"
@@ -10,17 +12,22 @@ scope="{{ scopes }}"
 skip_provider_button="true"
 {%- endif %}
 
+{%- if authenticated_emails_file or authenticated_email_domains %}
 {%- if authenticated_emails_file %}
 authenticated_emails_file="{{ authenticated_emails_file }}"
+{%- endif %}
+{%- if authenticated_email_domains %}
+email_domains={{ authenticated_email_domains }}
+{%- endif %}
 {%- else %}
 email_domains="*"
 {%- endif %}
 set_xauthrequest="true"
-# TODO: Fetch endpoints that are allowed to bypass authentication
-# skip_auth_routes="GET=^/anything/allowed"
+{%- if skip_auth_routes %}
+skip_auth_routes={{ skip_auth_routes }}
+{%- endif %}
 
-# TODO: Update when forward-auth integration in place
 # Mandatory option when using oauth2-proxy with traefik
-# reverse_proxy="true"
+reverse_proxy="true"
 # Required for traefik with ForwardAuth and static upstream configuration
-# upstreams="static://202"
+upstreams="static://202"

--- a/tests/integration/auth-proxy-requirer/charmcraft.yaml
+++ b/tests/integration/auth-proxy-requirer/charmcraft.yaml
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: auth-proxy-requirer
+type: charm
+description: Auth Proxy Requirer Tester
+summary: Auth Proxy Requirer Tester
+bases:
+  - build-on:
+      - name: "ubuntu"
+        channel: "22.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "22.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - jsonschema
+      - ops
+      - pydantic
+    build-packages:
+      - git
+
+assumes:
+  - k8s-api
+
+containers:
+  httpbin:
+    resource: oci-image
+resources:
+  oci-image:
+    type: oci-image
+    description: OCI image for IAP Tester container
+    upstream-source: kennethreitz/httpbin
+
+requires:
+  auth-proxy:
+    interface: auth_proxy
+    limit: 1
+  ingress:
+    interface: ingress

--- a/tests/integration/auth-proxy-requirer/requirements.txt
+++ b/tests/integration/auth-proxy-requirer/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema
+ops

--- a/tests/integration/auth-proxy-requirer/src/charm.py
+++ b/tests/integration/auth-proxy-requirer/src/charm.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+
+from charms.oauth2_proxy_k8s.v0.auth_proxy import AuthProxyConfig, AuthProxyRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
+from ops.charm import CharmBase, PebbleReadyEvent
+from ops.main import main
+from ops.model import ActiveStatus
+from ops.pebble import Layer
+
+AUTH_PROXY_ALLOWED_ENDPOINTS = ["anything/allowed"]
+AUTH_PROXY_HEADERS = ["X-Auth-Request-User", "X-Auth-Request-Groups", "X-Auth-Request-Email"]
+AUTH_PROXY_AUTHENTICATED_EMAILS = ["test@canonical.com", "test1@canonical.com"]
+AUTH_PROXY_AUTHENTICATED_EMAIL_DOMAINS = ["example.com"]
+HTTPBIN_PORT = 80
+
+logger = logging.getLogger(__name__)
+
+
+class AuthProxyRequirerMock(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self._container = self.unit.get_container("httpbin")
+        self._service_name = "httpbin"
+
+        self.ingress = IngressPerAppRequirer(
+            self,
+            host=f"{self.app.name}.{self.model.name}.svc.cluster.local",
+            relation_name="ingress",
+            port=HTTPBIN_PORT,
+            strip_prefix=True,
+        )
+
+        self.auth_proxy_relation_name = "auth-proxy"
+        self.auth_proxy = AuthProxyRequirer(
+            self, self._auth_proxy_config, self.auth_proxy_relation_name
+        )
+
+        self.framework.observe(self.on.httpbin_pebble_ready, self._on_httpbin_pebble_ready)
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+
+    @property
+    def _auth_proxy_config(self) -> AuthProxyConfig:
+        return AuthProxyConfig(
+            protected_urls=[
+                self.ingress.url if self.ingress.url is not None else "https://some-test-url.com"
+            ],
+            headers=AUTH_PROXY_HEADERS,
+            allowed_endpoints=AUTH_PROXY_ALLOWED_ENDPOINTS,
+            authenticated_emails=AUTH_PROXY_AUTHENTICATED_EMAILS,
+            authenticated_email_domains=AUTH_PROXY_AUTHENTICATED_EMAIL_DOMAINS
+        )
+
+    @property
+    def _httpbin_pebble_layer(self) -> Layer:
+        layer_config = {
+            "summary": "auth-proxy-requirer-mock layer",
+            "description": "pebble config layer for auth-proxy-requirer-mock",
+            "services": {
+                self._service_name: {
+                    "override": "replace",
+                    "summary": "httpbin layer",
+                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                    "startup": "enabled",
+                }
+            },
+        }
+        return Layer(layer_config)
+
+    def _on_httpbin_pebble_ready(self, event: PebbleReadyEvent) -> None:
+        self._container.add_layer("httpbin", self._httpbin_pebble_layer, combine=True)
+        self._container.replan()
+        self.unit.open_port(protocol="tcp", port=HTTPBIN_PORT)
+
+        self.unit.status = ActiveStatus()
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:
+        if self.unit.is_leader():
+            logger.info(f"This app's ingress URL: {event.url}")
+        self.auth_proxy.update_auth_proxy_config(auth_proxy_config=self._auth_proxy_config)
+
+
+if __name__ == "__main__":
+    main(AuthProxyRequirerMock)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 IMAGE_PATH = METADATA["resources"]["oauth2-proxy-image"]["upstream-source"]
 TRAEFIK = "traefik-k8s"
+AUTH_PROXY_REQUIRER = "auth-proxy-requirer"
 
 
 async def get_k8s_service_address(ops_test: OpsTest, service_name: str, lightkube_client: Client) -> Optional[str]:
@@ -102,3 +103,116 @@ async def test_health_checks(ops_test: OpsTest, lightkube_client: Client) -> Non
 
     response = requests.get(base_url, timeout=300, verify=False)
     assert response.status_code == 403
+
+
+@pytest.mark.abort_on_fail
+async def test_auth_proxy_relation(ops_test: OpsTest) -> None:
+    """Ensure that oauth2-proxy is able to provide auth-proxy relation."""
+    requirer_charm_path = Path(f"tests/integration/{AUTH_PROXY_REQUIRER}").absolute()
+    requirer_charm = await ops_test.build_charm(requirer_charm_path, verbosity="debug")
+
+    await ops_test.model.deploy(
+        application_name=AUTH_PROXY_REQUIRER,
+        entity_url=requirer_charm,
+        resources={"oci-image": "kennethreitz/httpbin"},
+        series="jammy",
+        trust=True,
+    )
+
+    await ops_test.model.integrate(f"{AUTH_PROXY_REQUIRER}:ingress", TRAEFIK)
+    await ops_test.model.integrate(f"{AUTH_PROXY_REQUIRER}:auth-proxy", APP_NAME)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, AUTH_PROXY_REQUIRER, TRAEFIK],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1000,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_forward_auth_relation(ops_test: OpsTest) -> None:
+    """Ensure that oauth2-proxy is able to provide forward-auth relation."""
+    await ops_test.model.applications[TRAEFIK].set_config({
+        "enable_experimental_forward_auth": "True"
+    })
+    await ops_test.model.integrate(f"{TRAEFIK}:experimental-forward-auth", APP_NAME)
+
+    await ops_test.model.wait_for_idle([TRAEFIK, APP_NAME], status="active", timeout=1000)
+
+
+@retry(
+    wait=wait_exponential(multiplier=3, min=1, max=20),
+    stop=stop_after_attempt(10),
+    reraise=True,
+)
+async def test_allowed_forward_auth_url_redirect(ops_test: OpsTest, lightkube_client: Client) -> None:
+    """Test that a request hitting a protected application is forwarded by traefik to oauth2 proxy.
+
+    An allowed request should be performed without authentication.
+    Retry the request to ensure the right config was populated to oauth2 proxy.
+    """
+    requirer_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK, AUTH_PROXY_REQUIRER, lightkube_client)
+
+    protected_url = join(requirer_url, "anything/allowed")
+
+    resp = requests.get(protected_url, verify=False)
+    assert resp.status_code == 200
+
+
+async def test_protected_forward_auth_url_redirect(ops_test: OpsTest, lightkube_client: Client) -> None:
+    """Test reaching a protected url.
+
+    The request should be forwarded by traefik to oauth2 proxy.
+    An unauthenticated request should then be denied with 403 response.
+    """
+    requirer_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK, AUTH_PROXY_REQUIRER, lightkube_client)
+
+    protected_url = join(requirer_url, "anything/deny")
+
+    resp = requests.get(protected_url, verify=False)
+    assert resp.status_code == 403
+
+
+async def test_oauth2_proxy_scale_up(ops_test: OpsTest) -> None:
+    """Check that OAuth2 Proxy works after it is scaled up."""
+    app = ops_test.model.applications[APP_NAME]
+
+    await app.scale(2)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1000,
+        wait_for_active=True,
+    )
+
+
+async def test_oauth2_proxy_scale_down(ops_test: OpsTest) -> None:
+    """Check that OAuth2 Proxy works after it is scaled down."""
+    app = ops_test.model.applications[APP_NAME]
+
+    await app.scale(1)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1000,
+        wait_for_active=True,
+    )
+
+
+async def test_remove_forward_auth_integration(ops_test: OpsTest) -> None:
+    """Ensure that the forward-auth relation doesn't cause errors on removal."""
+    await ops_test.juju("remove-relation", APP_NAME, f"{TRAEFIK}:experimental-forward-auth")
+
+    await ops_test.model.wait_for_idle([TRAEFIK, APP_NAME], status="active")
+
+
+async def test_remove_auth_proxy_integration(ops_test: OpsTest) -> None:
+    """Ensure that the auth-proxy relation doesn't cause errors on removal."""
+    await ops_test.juju("remove-relation", APP_NAME, f"{AUTH_PROXY_REQUIRER}:auth-proxy")
+
+    await ops_test.model.wait_for_idle([AUTH_PROXY_REQUIRER, APP_NAME], status="active")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,3 +30,13 @@ def mocked_container() -> MagicMock:
 @pytest.fixture()
 def mocked_cookie_encryption_key(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("charm.Oauth2ProxyK8sOperatorCharm._cookie_encryption_key", return_value="WrfOcYmVBwyduEbKYTUhO4X7XVaOQ1wF")
+
+
+@pytest.fixture()
+def mocked_oauth2_proxy_is_running(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.Oauth2ProxyK8sOperatorCharm._oauth2_proxy_service_is_running", return_value=True)
+
+
+@pytest.fixture
+def mocked_forward_auth_update(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charms.oauth2_proxy_k8s.v0.forward_auth.ForwardAuthProvider.update_forward_auth_config")

--- a/tests/unit/test_auth_proxy_provider.py
+++ b/tests/unit/test_auth_proxy_provider.py
@@ -1,0 +1,89 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from typing import Any, Generator, List
+
+import pytest
+from charms.oauth2_proxy_k8s.v0.auth_proxy import (
+    AuthProxyConfigChangedEvent,
+    AuthProxyConfigRemovedEvent,
+    AuthProxyProvider,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase
+from ops.testing import Harness
+
+METADATA = """
+name: provider-tester
+provides:
+  auth-proxy:
+    interface: auth_proxy
+"""
+
+
+class AuthProxyProviderCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.auth_proxy = AuthProxyProvider(self)
+        self.events: List = []
+
+        self.framework.observe(self.auth_proxy.on.proxy_config_changed, self._record_event)
+        self.framework.observe(self.auth_proxy.on.config_removed, self._record_event)
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture()
+def harness() -> Generator:
+    harness = Harness(AuthProxyProviderCharm, meta=METADATA)
+    harness.set_leader(True)
+    harness.begin()
+    yield harness
+    harness.cleanup()
+
+
+def setup_requirer_relation(harness: Harness) -> int:
+    relation_id = harness.add_relation("auth-proxy", "requirer")
+    harness.add_relation_unit(relation_id, "requirer/0")
+    harness.update_relation_data(
+        relation_id,
+        "requirer",
+        {
+            "protected_urls": '["https://example.com"]',
+            "allowed_endpoints": '["welcome", "about/app"]',
+            "headers": '["X-Auth-Request-User"]',
+            "authenticated_emails": '["test@example.com"]',
+            "authenticated_email_domains": '["canonical.com"]',
+        },
+    )
+
+    return relation_id
+
+
+class TestAuthProxyProviderIntegration:
+    def test_auth_proxy_config_changed_event_emitted_when_relation_changed(self, harness: Harness) -> None:
+        _ = setup_requirer_relation(harness)
+
+        assert any(isinstance(e, AuthProxyConfigChangedEvent) for e in harness.charm.events)
+
+    def test_auth_proxy_config_changed_event_not_emitted_when_invalid_config_provided(self, harness: Harness) -> None:
+        relation_id = harness.add_relation("auth-proxy", "requirer")
+        harness.add_relation_unit(relation_id, "requirer/0")
+        harness.update_relation_data(
+            relation_id,
+            "requirer",
+            {
+                "protected_urls": "invalid-url",
+                "allowed_endpoints": '["welcome", "about/app"]',
+                "headers": '["X-User"]',
+            },
+        )
+
+        assert not any(isinstance(e, AuthProxyConfigChangedEvent) for e in harness.charm.events)
+
+    def test_auth_proxy_config_removed_event_emitted_when_relation_removed(self, harness: Harness) -> None:
+        relation_id = setup_requirer_relation(harness)
+        harness.remove_relation(relation_id)
+
+        assert any(isinstance(e, AuthProxyConfigRemovedEvent) for e in harness.charm.events)

--- a/tests/unit/test_auth_proxy_requirer.py
+++ b/tests/unit/test_auth_proxy_requirer.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from typing import Any, Dict, Generator, List
+
+import pytest
+from charms.oauth2_proxy_k8s.v0.auth_proxy import (
+    AuthProxyConfig,
+    AuthProxyConfigError,
+    AuthProxyRelationRemovedEvent,
+    AuthProxyRequirer,
+    InvalidAuthProxyConfigEvent,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase
+from ops.testing import Harness
+
+METADATA = """
+name: requirer-tester
+requires:
+  auth-proxy:
+    interface: auth_proxy
+"""
+
+AUTH_PROXY_CONFIG = {
+    "protected_urls": ["https://example.com"],
+    "allowed_endpoints": ["welcome", "about/app"],
+    "headers": ["X-Auth-Request-User"],
+    "authenticated_emails": ["test@example.com"],
+    "authenticated_email_domains": ["canonical.com"],
+}
+
+
+@pytest.fixture()
+def harness() -> Generator:
+    harness = Harness(AuthProxyRequirerCharm, meta=METADATA)
+    harness.set_leader(True)
+    harness.begin_with_initial_hooks()
+    yield harness
+    harness.cleanup()
+
+
+def dict_to_relation_data(dic: Dict) -> Dict:
+    return {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in dic.items()}
+
+
+class AuthProxyRequirerCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        auth_proxy_config = AuthProxyConfig(**AUTH_PROXY_CONFIG)
+        self.auth_proxy = AuthProxyRequirer(self, auth_proxy_config=auth_proxy_config)
+
+        self.events: List = []
+        self.framework.observe(self.auth_proxy.on.invalid_auth_proxy_config, self._record_event)
+        self.framework.observe(self.auth_proxy.on.auth_proxy_relation_removed, self._record_event)
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+class TestAuthProxyRequirerIntegration:
+    def test_data_in_relation_bag(self, harness: Harness) -> None:
+        relation_id = harness.add_relation("auth-proxy", "provider")
+        relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
+
+        assert relation_data == dict_to_relation_data(AUTH_PROXY_CONFIG)
+
+    def test_warning_when_http_protected_url_provided(self, harness: Harness, caplog: pytest.LogCaptureFixture) -> None:
+        """Check that a warning appears when one of the provided urls uses http scheme."""
+        caplog.set_level(logging.WARNING)
+        auth_proxy_config = AuthProxyConfig(**AUTH_PROXY_CONFIG)
+        auth_proxy_config.protected_urls = ["https://some-url.com", "http://some-other-url.com"]
+
+        harness.charm.auth_proxy.update_auth_proxy_config(auth_proxy_config=auth_proxy_config)
+        assert (
+            f"Provided URL {auth_proxy_config.protected_urls[1]} uses http scheme. Don't do this in production"
+            in caplog.text
+        )
+
+    def test_exception_raised_when_invalid_protected_url(self, harness: Harness) -> None:
+        auth_proxy_config = AuthProxyConfig(**AUTH_PROXY_CONFIG)
+        auth_proxy_config.protected_urls = ["https://some-valid-url.com", "invalid-url"]
+
+        with pytest.raises(
+            AuthProxyConfigError, match=f"Invalid URL {auth_proxy_config.protected_urls[1]}"
+        ):
+            harness.charm.auth_proxy.update_auth_proxy_config(auth_proxy_config=auth_proxy_config)
+
+    def test_exception_raised_when_invalid_header(self, harness: Harness) -> None:
+        auth_proxy_config = AuthProxyConfig(**AUTH_PROXY_CONFIG)
+        auth_proxy_config.headers = ["X-Auth-Request-User", "X-Invalid-Header"]
+
+        with pytest.raises(AuthProxyConfigError, match="Unsupported header"):
+            harness.charm.auth_proxy.update_auth_proxy_config(auth_proxy_config=auth_proxy_config)
+
+    def test_auth_proxy_relation_removed_event_emitted(self, harness: Harness) -> None:
+        relation_id = harness.add_relation("auth-proxy", "provider")
+        harness.add_relation_unit(relation_id, "provider/0")
+
+        harness.remove_relation(relation_id)
+
+        assert any(isinstance(e, AuthProxyRelationRemovedEvent) for e in harness.charm.events)
+
+
+class InvalidConfigAuthProxyRequirerCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        auth_proxy_config = AuthProxyConfig(**AUTH_PROXY_CONFIG)
+        auth_proxy_config.headers = ["X-Invalid-Header"]
+        self.auth_proxy = AuthProxyRequirer(self, auth_proxy_config=auth_proxy_config)
+
+        self.events: List = []
+        self.framework.observe(self.auth_proxy.on.invalid_auth_proxy_config, self._record_event)
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture()
+def harness_invalid_config() -> Generator:
+    harness = Harness(InvalidConfigAuthProxyRequirerCharm, meta=METADATA)
+    harness.set_leader(True)
+    harness.begin_with_initial_hooks()
+    yield harness
+    harness.cleanup()
+
+
+class TestAuthProxyRequirerIntegrationInvalidConfig:
+    def test_event_emitted_when_invalid_auth_proxy_config(self, harness_invalid_config: Harness) -> None:
+        harness_invalid_config.add_relation("auth-proxy", "provider")
+
+        assert any(
+            isinstance(e, InvalidAuthProxyConfigEvent) for e in harness_invalid_config.charm.events
+        )

--- a/tests/unit/test_forward_auth_provider.py
+++ b/tests/unit/test_forward_auth_provider.py
@@ -1,0 +1,115 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+from typing import Any, Dict, Generator, List
+
+import pytest
+from charms.oauth2_proxy_k8s.v0.forward_auth import (
+    ForwardAuthConfig,
+    ForwardAuthProvider,
+    ForwardAuthProxySet,
+    ForwardAuthRelationRemovedEvent,
+    InvalidForwardAuthConfigEvent,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase
+from ops.testing import Harness
+
+METADATA = """
+name: provider-tester
+provides:
+  forward-auth:
+    interface: forward_auth
+"""
+FORWARD_AUTH_CONFIG = {
+    "decisions_address": "https://oauth2-proxy-k8s.testing.svc.cluster.local:4180",
+    "app_names": ["charmed-app"],
+    "headers": ["X-Auth-Request-User"],
+}
+
+
+class ForwardAuthProviderCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        forward_auth_config = ForwardAuthConfig(**FORWARD_AUTH_CONFIG)
+        self.forward_auth = ForwardAuthProvider(self, forward_auth_config=forward_auth_config)
+        self.events: List = []
+
+        self.framework.observe(self.forward_auth.on.forward_auth_proxy_set, self._record_event)
+        self.framework.observe(
+            self.forward_auth.on.invalid_forward_auth_config, self._record_event
+        )
+        self.framework.observe(
+            self.forward_auth.on.forward_auth_relation_removed, self._record_event
+        )
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture()
+def harness() -> Generator:
+    harness = Harness(ForwardAuthProviderCharm, meta=METADATA)
+    harness.set_model_name("testing")
+    harness.set_leader(True)
+    harness.begin_with_initial_hooks()
+    yield harness
+    harness.cleanup()
+
+
+def setup_requirer_relation(harness: Harness) -> int:
+    relation_id = harness.add_relation("forward-auth", "requirer")
+    harness.add_relation_unit(relation_id, "requirer/0")
+    harness.update_relation_data(
+        relation_id,
+        "requirer",
+        {"ingress_app_names": '["charmed-app"]'},
+    )
+
+    return relation_id
+
+
+def dict_to_relation_data(dic: Dict) -> Dict:
+    return {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in dic.items()}
+
+
+class TestForwardAuthProviderIntegration:
+    def test_data_in_relation_bag(self, harness: Harness) -> None:
+        relation_id = harness.add_relation("forward-auth", "requirer")
+        relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
+
+        assert relation_data == dict_to_relation_data(FORWARD_AUTH_CONFIG)
+
+    def test_missing_forward_auth_config_logged(
+        self, harness: Harness, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.INFO)
+
+        harness.charm.forward_auth.update_forward_auth_config(forward_auth_config="")
+        assert "Forward-auth config is missing" in caplog.text
+
+    def test_forward_auth_proxy_set_emitted_when_valid_config_provided(self, harness: Harness) -> None:
+        _ = setup_requirer_relation(harness)
+
+        assert any(isinstance(e, ForwardAuthProxySet) for e in harness.charm.events)
+
+    def test_forward_auth_invalid_config_emitted_when_app_not_related_to_ingress(
+        self, harness: Harness,
+    ) -> None:
+        relation_id = harness.add_relation("forward-auth", "requirer")
+        harness.add_relation_unit(relation_id, "requirer/0")
+        harness.update_relation_data(
+            relation_id,
+            "requirer",
+            {"ingress_app_names": '["other-app"]'},
+        )
+
+        assert any(isinstance(e, InvalidForwardAuthConfigEvent) for e in harness.charm.events)
+
+    def test_forward_auth_removed_emitted_when_relation_removed(self, harness: Harness) -> None:
+        relation_id = setup_requirer_relation(harness)
+        harness.remove_relation(relation_id)
+
+        assert any(isinstance(e, ForwardAuthRelationRemovedEvent) for e in harness.charm.events)

--- a/tests/unit/test_forward_auth_requirer.py
+++ b/tests/unit/test_forward_auth_requirer.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from typing import Any, Dict, Generator, List
+
+import pytest
+from charms.oauth2_proxy_k8s.v0.forward_auth import (
+    AuthConfigChangedEvent,
+    AuthConfigRemovedEvent,
+    ForwardAuthRequirer,
+    ForwardAuthRequirerConfig,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase
+from ops.testing import Harness
+
+METADATA = """
+name: requirer-tester
+requires:
+  forward-auth:
+    interface: forward_auth
+    limit: 1
+"""
+
+FORWARD_AUTH_REQUIRER_CONFIG = {
+    "ingress_app_names": ["charmed-app"],
+}
+
+
+@pytest.fixture()
+def harness() -> Generator:
+    harness = Harness(ForwardAuthRequirerCharm, meta=METADATA)
+    harness.set_leader(True)
+    harness.begin_with_initial_hooks()
+    yield harness
+    harness.cleanup()
+
+
+@pytest.fixture()
+def provider_info() -> Dict:
+    return {
+        "decisions_address": "https://oauth2-proxy-k8s.testing.svc.cluster.local:4180",
+        "app_names": ["charmed-app"],
+        "headers": ["X-User"],
+    }
+
+
+def dict_to_relation_data(dic: Dict) -> Dict:
+    return {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in dic.items()}
+
+
+class ForwardAuthRequirerCharm(CharmBase):
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.forward_auth = ForwardAuthRequirer(self)
+
+        self.events: List = []
+        self.framework.observe(self.forward_auth.on.auth_config_changed, self._record_event)
+        self.framework.observe(self.forward_auth.on.auth_config_removed, self._record_event)
+
+    def _record_event(self, event: EventBase) -> None:
+        self.events.append(event)
+
+
+def setup_provider_relation(harness: Harness) -> int:
+    relation_id = harness.add_relation("forward-auth", "provider")
+    harness.add_relation_unit(relation_id, "provider/0")
+    harness.update_relation_data(
+        relation_id,
+        "provider",
+        {
+            "decisions_address": "https://oauth2-proxy-k8s.testing.svc.cluster.local:4180",
+            "app_names": '["charmed-app"]',
+            "headers": '["X-User"]',
+        },
+    )
+
+    return relation_id
+
+
+class TestForwardAuthRequirerIntegration:
+    def test_data_in_relation_bag(self, harness: Harness) -> None:
+        relation_id = harness.add_relation("forward-auth", "provider")
+        relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
+
+        # Call update_requirer_relation_data() to mimic traefik behaviour
+        forward_auth_requirer_config = ForwardAuthRequirerConfig(**FORWARD_AUTH_REQUIRER_CONFIG)
+        harness.charm.forward_auth.update_requirer_relation_data(forward_auth_requirer_config)
+
+        assert relation_data == dict_to_relation_data(FORWARD_AUTH_REQUIRER_CONFIG)
+
+    def test_get_provider_info_when_data_available(self, harness: Harness, provider_info: Dict) -> None:
+        _ = setup_provider_relation(harness)
+
+        expected_provider_info = harness.charm.forward_auth.get_provider_info()
+
+        assert expected_provider_info.decisions_address == provider_info["decisions_address"]
+        assert expected_provider_info.app_names == provider_info["app_names"]
+        assert expected_provider_info.headers == provider_info["headers"]
+
+    def test_forward_auth_config_changed_emitted_when_relation_changed(self, harness: Harness) -> None:
+        _ = setup_provider_relation(harness)
+
+        assert any(isinstance(e, AuthConfigChangedEvent) for e in harness.charm.events)
+
+    def test_forward_auth_removed_emitted_when_relation_removed(self, harness: Harness) -> None:
+        relation_id = setup_provider_relation(harness)
+        harness.remove_relation(relation_id)
+
+        assert any(isinstance(e, AuthConfigRemovedEvent) for e in harness.charm.events)

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist = fmt, lint, unit, integration
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-; lib_path = {toxinidir}/lib/charms/oauth2_proxy_k8s
-all_path = {[vars]src_path} {[vars]tst_path}
+lib_path = {toxinidir}/lib/charms/oauth2_proxy_k8s
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 setenv =
@@ -58,7 +58,7 @@ description = Run unit tests
 deps =
     -r{toxinidir}/unit-requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
+    coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -vv --tb native -s {posargs}
     coverage report
 


### PR DESCRIPTION
This PR adds e2e integration with Traefik ForwardAuth middleware and charmed apps requesting the proxy.