### PR TITLE
chore: switch to platforms in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,13 +17,8 @@ links:
   source: https://github.com/canonical/oauth2-proxy-k8s-operator
   issues: https://github.com/canonical/oauth2-proxy-k8s-operator/issues
 
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
+platforms:
+  ubuntu@22.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
This PR changes the charm's charmcraft `bases` and `platform` to `platforms`. This is needed to add main branch to charmcraftcache builds and switch to reusable workflows.