### PR TITLE
fix: address setuptools CVEs

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -25,6 +25,7 @@ parts:
     charm-binary-python-packages:
       - jsonschema
       - pydantic
+      - "setuptools>=70.0.0"
 
 config:
   options:


### PR DESCRIPTION
- patch setuptools related cves:

* CVE-2024-6345
* CVE-2022-40897

closes https://github.com/canonical/oauth2-proxy-k8s-operator/issues/67