### PR TITLE
fix: switch usptreams status code to 200

### DIFF
--- a/templates/oauth2-proxy.toml.j2
+++ b/templates/oauth2-proxy.toml.j2
@@ -32,4 +32,4 @@ skip_auth_routes={{ skip_auth_routes }}
 # Mandatory option when using oauth2-proxy with traefik
 reverse_proxy="true"
 # Required for traefik with ForwardAuth and static upstream configuration
-upstreams="static://202"
+upstreams="static://200"


### PR DESCRIPTION
While Traefik interprets any 20x status from OAuth2 Proxy as a successful authentication, Istio expects 200 for allowed requests.
Changing the `--upstreams` static response code from 202 to 200 has the same effect on the flow and is compatible with both Traefik and Istio.

fixes https://github.com/canonical/oauth2-proxy-k8s-operator/issues/72