### PR TITLE
fix: record app name in databag

### DIFF
--- a/tests/unit/test_auth_proxy_requirer.py
+++ b/tests/unit/test_auth_proxy_requirer.py
@@ -65,7 +65,13 @@ class TestAuthProxyRequirerIntegration:
         relation_id = harness.add_relation("auth-proxy", "provider")
         relation_data = harness.get_relation_data(relation_id, harness.model.app.name)
 
-        assert relation_data == dict_to_relation_data(AUTH_PROXY_CONFIG)
+        expected_data = dict_to_relation_data(AUTH_PROXY_CONFIG)
+
+        assert relation_data["app_name"] == "requirer-tester"
+        assert relation_data["allowed_endpoints"] == expected_data["allowed_endpoints"]
+        assert relation_data["headers"] == expected_data["headers"]
+        assert relation_data["authenticated_emails"] == expected_data["authenticated_emails"]
+        assert relation_data["authenticated_email_domains"] == expected_data["authenticated_email_domains"]
 
     def test_warning_when_http_protected_url_provided(
         self, harness: Harness, caplog: pytest.LogCaptureFixture

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -88,6 +88,7 @@ def setup_auth_proxy_relation(
         relation_id,
         app_name,
         {
+            "app_name": "requirer",
             "protected_urls": '["https://example.com"]',
             "allowed_endpoints": '["about/app"]',
             "headers": '["X-Auth-Request-User", "X-Auth-Request-Groups"]',


### PR DESCRIPTION
fixes https://github.com/canonical/oauth2-proxy-k8s-operator/issues/90

The auth-proxy charm names should be captured in the relation databag when a requirer joins the relation rather than fetched from `Relation` object as application names are anonymised to the offerer side in cross-model integrations.
As a result, the databag will look as follows:
````
traefik-k8s/0:
  workload-version: 2.11.0
  opened-ports: []
  charm: ch:amd64/traefik-k8s-236
  leader: true
  life: alive
  relation-info:
  - relation-id: 3
    endpoint: experimental-forward-auth
    related-endpoint: forward-auth
    application-data:
      app_names: '["auth-proxy-requirer", "another-charm"]'
      decisions_address: http://oauth2-proxy-k8s.test.svc.cluster.local:4180
      headers: '["X-Auth-Request-Email", "X-Auth-Request-User", "X-Auth-Request-Groups"]'
    related-units:
      oauth2-proxy-k8s/0:
        in-scope: true
        data:
          egress-subnets: 10.152.183.18/32
          ingress-address: 10.152.183.18
          private-address: 10.152.183.18
```