### PR TITLE
docs: add info on certificates integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,10 @@ charmcraft pack && juju refresh --path="./*amd64.charm" oauth2-proxy-k8s --force
 # Deploy traefik operator
 juju deploy traefik-k8s traefik-public --channel latest/stable --trust
 
+# Deploy certificates operator and integrate it with traefik
+juju deploy self-signed-certificates --channel 1/stable --trust
+juju integrate self-signed-certificates:certificates traefik-public
+
 # Integrate traefik with oauth2-proxy
 juju integrate oauth2-proxy-k8s:ingress traefik-public
 juju config traefik-public enable_experimental_forward_auth=True
@@ -118,6 +122,9 @@ juju integrate oauth2-proxy-k8s traefik-public:experimental-forward-auth
 
 # Deploy Identity Platform
 juju deploy identity-platform --channel latest/edge --trust
+
+# Integrate with certificates charm
+juju integrate oauth2-proxy-k8s:receive-ca-cert self-signed-certificates
 
 # Integrate with oauth
 juju integrate oauth2-proxy-k8s:oauth hydra

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ juju deploy traefik-k8s traefik-public --channel latest/stable --trust
 juju integrate traefik-public oauth2-proxy-k8s:ingress
 ```
 
+### Certificates
+
+OAuth2 Proxy offers integration with [self-signed-certificates](https://charmhub.io/self-signed-certificates).
+This integration allows OAuth2 Proxy to receive CA certificates so that it can trust Hydra, the OAuth provider.
+
+It can be added by deploying the `self-signed-certificates` charm and establishing integrations:
+
+```commandline
+juju deploy self-signed-certificates --channel 1/stable --trust
+juju integrate self-signed-certificates:certificates traefik-public
+juju integrate oauth2-proxy-k8s:receive-ca-cert self-signed-certificates
+```
+
+> Note: Deploy `self-signed-certificates` from the `1/stable` channel or higher.
+
 ### Traefik ForwardAuth
 
 OAuth2 Proxy offers integration with
@@ -93,6 +108,12 @@ juju integrate oauth2-proxy-k8s:oauth hydra
 ```
 
 Note that `oauth` requires `ingress` integration provided by Traefik Charmed Operator.
+
+In order to trust the OAuth provider, you must also integrate OAuth2 Proxy
+with `receive-ca-cert` (e.g. using charmed [lego](https://charmhub.io/lego) or [self-signed-certificates](https://charmhub.io/self-signed-certificates)).
+
+Alternatively, for development purposes you can bypass certificate validation by setting `juju config oauth2-proxy-k8s dev=true`.
+Don't do this in production.
 
 ## Security
 


### PR DESCRIPTION
`self-signed certificates-operator` used to write the certificate in unit data in `latest/stable` release, while in `1/stable` it is placed in application data instead.
[#94](https://github.com/canonical/oauth2-proxy-k8s-operator/pull/94) adapted OAuth2 Proxy to support `1/stable`, but the charm became incompatible with older versions of `self-signed-certificates`. This PR documents it in the readme.