### PR TITLE
fix: keyerror app name

### DIFF
--- a/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
+++ b/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
@@ -372,7 +372,7 @@ class AuthProxyProvider(AuthProxyRelation):
 
         app_names = []
         for relation in self._charm.model.relations[self._relation_name]:
-            if relation.data[relation.]app:
+            if relation.data[relation.app]:
                 app_names.append(relation.app.name)
 
         return app_names


### PR DESCRIPTION
Fixes the following error:
```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 497, in <module>
    main.main(Oauth2ProxyK8sOperatorCharm)  # type: ignore
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/__init__.py", line 359, in main
    return _legacy_main.main(
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/main.py", line 39, in main
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/_main.py", line 502, in main
    manager = _Manager(charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/_main.py", line 315, in __init__
    self.charm = self._charm_class(self.framework)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 116, in __init__
    forward_auth_config=self._forward_auth_config,
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 207, in _forward_auth_config
    auth_proxy_data = AuthProxyIntegrationData.load(self.auth_proxy)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/src/integrations.py", line 32, in load
    app_names = provider.get_app_names()
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py", line 378, in get_app_names
    app_names.append(relation.data[relation.app]["app_name"])
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/model.py", line 2170, in __getitem__
    return super().__getitem__(key)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/model.py", line 904, in __getitem__
    return self._data[key]
KeyError: 'app_name'
```