### PR TITLE
fix: defensive data fetching

### DIFF
--- a/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
+++ b/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py
@@ -383,9 +383,9 @@ class AuthProxyProvider(AuthProxyRelation):
             return None
 
         relations_data = set()
-        for relation in self._charm.model.relations[self._relation_name]:
-            if relation.data[relation.app]:
-                if values := json.loads(relation.data[relation.app][key]):
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            if relation.data.get(relation.app, None):
+                if values := json.loads(relation.data[relation.app].get(key, "[]")):
                     for v in values:
                         relations_data.add(v)
                 else:


### PR DESCRIPTION
Fixes issues related to: 
```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 365, in <module>
    main(Oauth2ProxyK8sOperatorCharm)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/__init__.py", line 356, in __call__
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/_main.py", line 502, in main
    manager = _Manager(charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/_main.py", line 315, in __init__
    self.charm = self._charm_class(self.framework)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 110, in __init__
    forward_auth_config=self._forward_auth_config,
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/./src/charm.py", line 184, in _forward_auth_config
    auth_proxy_data = AuthProxyIntegrationData.load(self.auth_proxy)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/src/integrations.py", line 109, in load
    authenticated_emails = provider.get_relations_data("authenticated_emails")
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/lib/charms/oauth2_proxy_k8s/v0/auth_proxy.py", line 388, in get_relations_data
    if values := json.loads(relation.data[relation.app][key]):
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/model.py", line 2183, in __getitem__
    return super().__getitem__(key)
  File "/var/lib/juju/agents/unit-oauth2-proxy-k8s-0/charm/venv/ops/model.py", line 917, in __getitem__
    return self._data[key]
KeyError: 'authenticated_emails'
```