### PR TITLE
fix: pass valid memory key to KubernetesComputeResourcesPatch

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -357,7 +357,7 @@ class Oauth2ProxyK8sOperatorCharm(CharmBase):
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {"cpu": self.model.config.get("cpu"), "memory": self.model.config.get("memory")}
-        requests = {"cpu": "100m", "mem": "200Mi"}
+        requests = {"cpu": "100m", "memory": "200Mi"}
         return adjust_resource_requirements(limits, requests, adhere_to_requests=True)
 
 


### PR DESCRIPTION
fixes https://github.com/canonical/oauth2-proxy-k8s-operator/issues/144

Patching the k8s resources was failing due to invalid `mem` key. With this fix it is patched correctly:
```
unit-oauth2-proxy-k8s-0: 14:01:36 INFO juju.worker.uniter.operation ran "oauth2-proxy-pebble-ready" hook (via hook dispatching script: dispatch)
unit-oauth2-proxy-k8s-0: 14:01:36 INFO unit.oauth2-proxy-k8s/0.juju-log HTTP Request: GET https://10.152.183.1/apis/apps/v1/namespaces/test2/statefulsets/oauth2-proxy-k8s "HTTP/1.1 200 OK"
unit-oauth2-proxy-k8s-0: 14:01:36 INFO unit.oauth2-proxy-k8s/0.juju-log HTTP Request: GET https://10.152.183.1/apis/apps/v1/namespaces/test2/statefulsets/oauth2-proxy-k8s "HTTP/1.1 200 OK"
unit-oauth2-proxy-k8s-0: 14:01:36 INFO unit.oauth2-proxy-k8s/0.juju-log HTTP Request: PATCH https://10.152.183.1/apis/apps/v1/namespaces/test2/statefulsets/oauth2-proxy-k8s?fieldManager=ResourcePatcher "HTTP/1.1 200 OK"
unit-oauth2-proxy-k8s-0: 14:01:36 INFO unit.oauth2-proxy-k8s/0.juju-log Kubernetes resources for app 'oauth2-proxy-k8s', container 'oauth2-proxy' patched successfully: ResourceRequirements(claims=None, limits={}, requests={'cpu': '100m', 'memory': '200Mi'})
```