### PR TITLE
chore: pin traefik to rev263

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -54,6 +54,7 @@ def test_ingress_relation(juju: jubilant.Juju) -> None:
     juju.deploy(
         TRAEFIK,
         channel="latest/edge",
+        revision=263,
         trust=True,
     )
 


### PR DESCRIPTION
This PR pins the traefik-k8s charm to revision 263 to investigate and mitigate recent CI instability.
I couldn't reproduce it locally so I'll run it a few times with the self-hosted runners.

I am not sure the failure is caused by https://github.com/canonical/oauth2-proxy-k8s-operator/issues/209. The CI started failing only some time ago and the evidence suggests the root cause lies elsewhere, likely in recent traefik updates:
- The library code on both the requirer side and the pinned certificates provider has not been updated recently.
- We continue using self-signed-certificates (latest/stable rev264), which is unchanged from last months when CI was stable.
- The CI failures are flaky rather than consistent (see examples: [1](https://github.com/canonical/oauth2-proxy-k8s-operator/actions/runs/21353497572), [2](http://github.com/canonical/oauth2-proxy-k8s-operator/actions/runs/21350534379)). A malformed JSON error would typically cause a hard crash every time, yet the certificates charm eventually becomes active in these runs.