### PR TITLE
fix: handle status on update event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -286,6 +286,11 @@ class Oauth2ProxyK8sOperatorCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Status check: DOWN")
             return
 
+        if isinstance(self.unit.status, BlockedStatus):
+            return
+
+        self._holistic_handler(event)
+
     @log_event_handler(logger)
     def _on_oauth_info_changed(self, event: OAuthInfoChangedEvent) -> None:
         """Handle `oauth-info-changed` event.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -53,7 +53,7 @@ def test_build_and_deploy(juju: jubilant.Juju, local_charm: Path) -> None:
 def test_ingress_relation(juju: jubilant.Juju) -> None:
     juju.deploy(
         TRAEFIK,
-        channel="latest/edge",
+        channel="latest/stable",
         trust=True,
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -403,6 +403,35 @@ class TestUpdateStatusEvent:
 
         assert state_out.unit_status == MaintenanceStatus("Status check: DOWN")
 
+    def test_update_status_recovers_to_active(
+        self,
+        context: ops.testing.Context,
+        peer_relation: ops.testing.PeerRelation,
+        expected_pebble_layer: ops.pebble.Layer,
+    ) -> None:
+        container = ops.testing.Container(
+            name=WORKLOAD_CONTAINER,
+            can_connect=True,
+            layers={"oauth2-proxy": expected_pebble_layer},
+            check_infos={
+                ops.testing.CheckInfo(
+                    name=PEBBLE_READY_CHECK_NAME,
+                    status=CheckStatus.UP,
+                    level=CheckLevel.UNSET,
+                    startup=CheckStartup.UNSET,
+                    threshold=None,
+                )
+            },
+        )
+
+        state_in = create_state(relations=[peer_relation], container=container)
+        # Simulate MaintenanceStatus before running update event
+        state_in = replace(state_in, unit_status=MaintenanceStatus("Status check: DOWN"))
+
+        state_out = context.run(context.on.update_status(), state_in)
+
+        assert state_out.unit_status == ActiveStatus()
+
 
 class TestIngressIntegrationEvents:
     def test_ingress_relation_created(


### PR DESCRIPTION
fixes https://github.com/canonical/oauth2-proxy-k8s-operator/issues/278
- `update-status` now invokes the charm's holistic handler when the pebble container status check becomes `CheckStatus.UP`
 - To ensure that `update-status` does not overwrite an existing, intentional `BlockedStatus` (for example, when `forward-auth` config is invalid), we return early and preserve the blocked status.
